### PR TITLE
Update setup-kubetools.sh

### DIFF
--- a/setup-kubetools.sh
+++ b/setup-kubetools.sh
@@ -33,7 +33,7 @@ EOF
 	sudo apt-mark hold kubelet kubeadm kubectl
 	swapoff -a
 	
-	sed -i 's/swap/#swap/' /etc/fstab
+	sed -r -i 's/^([^#].*[[:space:]]swap[[:space:]].*)$/#\1/' /etc/fstab
 fi
 
 # Set iptables bridging


### PR DESCRIPTION
Current sed line breaks /etc/fstab as it puts the '#' between '/' and "swap".  Instead, match the fstype field ("swap" surrounded by spaces) and prepend a '#' to the beginning of the line if it does not already start with one (idempotent ;) ).