### PR TITLE
fix: setup-container-* scripts

### DIFF
--- a/setup-container-new.sh
+++ b/setup-container-new.sh
@@ -64,6 +64,7 @@ sudo install -m 755 runc.${PLATFORM} /usr/local/sbin/runc
         sudo systemctl enable --now containerd
 fi
 
+touch /tmp/container.txt
 exit
 #### notes from history just in case
 #!/bin/bash

--- a/setup-container-previous-version.sh
+++ b/setup-container-previous-version.sh
@@ -63,3 +63,5 @@ version = 2
 	sudo systemctl restart containerd	
 fi
 
+touch /tmp/container.txt
+exit


### PR DESCRIPTION
`setup-kubetools.sh` expects to see the `/tmp/container.txt` file as proof that the container setup script was run. For the newer versions of this script, the line that adds this had been omitted.